### PR TITLE
Made the deprecation macro work with gcc 5.0

### DIFF
--- a/libs/openFrameworks/utils/ofConstants.h
+++ b/libs/openFrameworks/utils/ofConstants.h
@@ -35,7 +35,7 @@ enum ofTargetPlatform{
 // Cross-platform deprecation warning
 #ifdef __GNUC__
 	// clang also has this defined. deprecated(message) is only for gcc>=4.5
-	#if (__GNUC__ >= 4) && (__GNUC_MINOR__ >= 5)
+	#if (__GNUC__ > 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ >= 5))
         #define OF_DEPRECATED_MSG(message, func) func __attribute__ ((deprecated(message)))
     #else
         #define OF_DEPRECATED_MSG(message, func) func __attribute__ ((deprecated))


### PR DESCRIPTION
Hi there! 
I work on the SFML library and we are currently implementing a deprecation macro. While looking at existing solutions someone on the forum noticed a bug in your implementation. `OF_DEPRECATED_MSG` won't work with GCC 5.0, because the minor version is no longer less than 5. I thought I should report this bug to the team.
